### PR TITLE
FilterでERB以外のテンプレートエンジン対応

### DIFF
--- a/handsaw.gemspec
+++ b/handsaw.gemspec
@@ -21,6 +21,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'redcarpet', '~> 3.3.4'
   s.add_dependency 'html-pipeline', '~> 2.4.2'
   s.add_dependency 'github-markdown'
+  s.add_dependency "slim-rails"
 
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "pry-rails"
+  s.add_development_dependency "pry-byebug"
 end

--- a/lib/handsaw/filters/indented_paragraph.rb
+++ b/lib/handsaw/filters/indented_paragraph.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'erb'
+require 'tilt'
 
 module Handsaw
   module Filters
@@ -33,9 +34,9 @@ module Handsaw
       end
 
       def template
-        open("app/processors/#{@context[:suffix]}/templates/#{@type}.html.erb") do |f|
-          ERB.new(f.read).result(binding)
-        end
+        template_file_name = Dir.glob("app/processors/#{@context[:suffix]}/templates/#{@type}.*")[0]
+        template = Tilt.new(template_file_name)
+        template.render(self)
       end
 
       def define_variable(item)

--- a/spec/dummy/app/processors/test/attention_filter.rb
+++ b/spec/dummy/app/processors/test/attention_filter.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class Test::AttentionFilter < Handsaw::Filters::IndentedParagraph
+end

--- a/spec/dummy/app/processors/test/templates/attention.slim
+++ b/spec/dummy/app/processors/test/templates/attention.slim
@@ -1,0 +1,5 @@
+.attention
+  - if @title
+    h3 = @title
+  .
+    = @value

--- a/spec/dummy/app/processors/test_processor.rb
+++ b/spec/dummy/app/processors/test_processor.rb
@@ -1,0 +1,2 @@
+class TestProcessor < Handsaw::BaseProcessor
+end


### PR DESCRIPTION
## 対応箇所

### テスト用環境の準備
- `spec/dummy`以下にRailsのテストアプリを構築
- pryとかdevelop用のgemを追加

### erb以外のビューテンプレートに対応
- Tiltを利用。
- slimを標準で追加
- テストアプリに`TestProcessor`を追加