### PR TITLE
Handsaw::Filters::IndentedParagraphの変数の初期化のバグ

### DIFF
--- a/lib/handsaw/filters/indented_paragraph.rb
+++ b/lib/handsaw/filters/indented_paragraph.rb
@@ -28,9 +28,9 @@ module Handsaw
           end
           @value = values.join.gsub(/^\s*$/, '')
           div.replace Nokogiri::HTML.fragment(CGI.unescapeHTML(compile))
+          (instance_variables - variables).each { |v| remove_instance_variable v }
         end
 
-        (instance_variables - variables).each { |v| remove_instance_variable v }
         doc
       end
 


### PR DESCRIPTION
#4 ←これの対応
