### PR TITLE
CGI.unescapeHTMLで can't dup NilClass とエラーが出力される問題の解決

### DIFF
--- a/lib/handsaw/filters/indented_paragraph.rb
+++ b/lib/handsaw/filters/indented_paragraph.rb
@@ -35,7 +35,7 @@ module Handsaw
       end
 
       def compile
-        template
+        template.to_str
       end
 
       def template


### PR DESCRIPTION
`ActiveSupport::SafeBuffer`型の文字列を`CGI.unescapeHTML`すると`can't dup NilClass`とエラーを吐くのでそれの対応

例えばこういうのを入れると死ぬ
```
link:
  href: https://itunes.apple.com/jp/app/connecting-dots-free-flowing/id621096424?mt=8&ign-mpt=uo%3D4
  title: hoge
```

参考
https://github.com/rails/rails/issues/12672