### PR TITLE
nokogiri v1.11.7対応

### DIFF
--- a/lib/handsaw/filters/br_parser.rb
+++ b/lib/handsaw/filters/br_parser.rb
@@ -4,7 +4,7 @@ module Handsaw
     class BrParser < HTML::Pipeline::Filter
       def call
         doc.search('.//text()').each do |t|
-          t.replace t.text.gsub(/\{br\}/, '') if t.text !~ /\A\s+\z/
+          t.replace t.text.gsub(/\{br\}/, '') if t.text !~ /\A\s+\z/ && t.text.match?(/br/)
         end
         doc
       end

--- a/lib/handsaw/filters/span_parser.rb
+++ b/lib/handsaw/filters/span_parser.rb
@@ -6,8 +6,8 @@ module Handsaw
       def call
         doc.search('.//text()').each do |t|
           if t.text !~ /\A\s+\z/
-            t.replace t.text.gsub(SPAN_REG, '<span class="\1">\2</span>')
-            t.replace t.text.gsub(/^{br}.*/, '')
+            t.replace t.text.gsub(SPAN_REG, '<span class="\1">\2</span>') if t.text.match?(SPAN_REG)
+            t.replace t.text.gsub(/^{br}.*/, '') if t.text.match?(/^{br}.*/)
           end
         end
         doc

--- a/lib/handsaw/version.rb
+++ b/lib/handsaw/version.rb
@@ -1,3 +1,3 @@
 module Handsaw
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
# 概要
- nokogiriのアップデートにより、replaceメソッドの挙動が変わった
    - https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#fixed-7
    - https://github.com/sparklemotion/nokogiri/blob/v1.11.7/lib/nokogiri/xml/node.rb#L259-L272
        - parent nodeがないnodeのreplaceができず、Plain Textのリプレイスができなくなり`raise("Cannot replace a node with no parent")`が発生
        - replace可能な条件下でのみreplaceを実行する