### PR TITLE
redcarpet 3.3.4以降に対応

### DIFF
--- a/handsaw.gemspec
+++ b/handsaw.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails"
   s.add_dependency "nokogiri"
-  s.add_dependency 'redcarpet', '~> 3.3.4'
+  s.add_dependency 'redcarpet', '>= 3.3.4'
   s.add_dependency 'html-pipeline', '~> 2.4.2'
   s.add_dependency 'github-markdown'
   s.add_dependency "slim-rails"


### PR DESCRIPTION
## 説明
ruby3系に対応するため、依存するgemのredcarpetのアップデートを実行した。
下記によれば、破壊的変更などはなさそうです。
- https://github.com/vmg/redcarpet/releases
- https://github.com/vmg/redcarpet/blob/v3.4.0/CHANGELOG.md

ブランチ名変更のため下記PRからこちらに移行しました
ref: https://github.com/PORT-INC/handsaw/pull/9

## 動作確認項目
1. このブランチからgemをインストール  e.g.```gem 'handsaw', github: 'PORT-INC/handsaw', branch: 'update-redcarpet-dependency'```
2. ```bundle update redcarpet```
3. chai の processors 下の spec を実行する。```bundle exec rspec spec/processors```